### PR TITLE
install: create the parent directory if necessary

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 INSTALL_DIR=${1:-/usr/local/bin}
 
+mkdir -p $INSTALL_DIR
 cp git-fresh $INSTALL_DIR && ([ -e $INSTALL_DIR/git-fresh ] && echo git-fresh installed in $INSTALL_DIR)


### PR DESCRIPTION
This ensures the parent directory always exists.
