### PR TITLE
Change dir to repo root before making changes

### DIFF
--- a/git-fresh
+++ b/git-fresh
@@ -185,6 +185,9 @@ recover_root () {
 
 recover_root
 
+LAST_WORKING_DIRECTORY="$(pwd)"
+cd "$TOP_LEVEL_DIRECTORY"
+
 ERR="could not get current commit"
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 ERR=""
@@ -376,6 +379,12 @@ if ! git gc --auto --force; then
   ERR="git prune failed"
   git prune
   rm -rf "$TOP_LEVEL_DIRECTORY/.git/gc.log"
+fi
+
+if [[ -d "$LAST_WORKING_DIRECTORY" ]]; then
+    cd "$LAST_WORKING_DIRECTORY"
+else
+    say "Previous working directory does not exist on the branch $ROOT"
 fi
 
 recover_root


### PR DESCRIPTION
Fixes #91 

1. Saves current working directory in `$LAST_WORKING_DIRECTORY`, before changes are made and changes directory to the root directory of repo, `$TOP_LEVEL_DIRECTORY`.
2. Changes directory to `$LAST_WORKING_DIRECTORY` if it exists, at the end when operations are over.

So, if the script "`die`s" in between, the directory is not changed to `$LAST_WORKING_DIRECTORY`. Is this desired? or the changes are required in "`trap` functions"?