### PR TITLE
Support for GIT_ROOT

### DIFF
--- a/git-fresh
+++ b/git-fresh
@@ -158,6 +158,7 @@ fi
 # Are we in a non-empty git repository?
 ERR="could not get top-level-directory"
 TOP_LEVEL_DIRECTORY=$(git rev-parse --show-toplevel)
+GIT_DIR=${GIT_DIR:-${TOP_LEVEL_DIRECTORY}}
 REMOTE=${1:-origin}
 
 ROOT_GUESS=master
@@ -170,7 +171,7 @@ ROOT=${2:-$ROOT_GUESS}
 
 # Recover the root HEAD if it is missing or corrupt (e.g. master head reads "master")
 recover_root () {
-  ROOT_HEAD_FILE="$TOP_LEVEL_DIRECTORY/.git/refs/heads/$ROOT"
+  ROOT_HEAD_FILE="${GIT_DIR}/refs/heads/$ROOT"
 
   if [[ -e "$ROOT_HEAD_FILE" ]]; then
     if [[ $(cat "$ROOT_HEAD_FILE") = $(echo $ROOT) ]]; then
@@ -182,7 +183,7 @@ recover_root () {
 
   if [[ "$CORRUPT_ROOT_HEAD" = "true" || "$MISSING_ROOT_HEAD" = "true" ]]; then
     ERR="failed to recover $ROOT HEAD"
-    RECOVERED_ROOT_HEAD=$(cat "$TOP_LEVEL_DIRECTORY/.git/logs/refs/heads/$ROOT" | tail -n1 | cut -d' ' -f2)
+    RECOVERED_ROOT_HEAD=$(cat "${GIT_DIR}/logs/refs/heads/$ROOT" | tail -n1 | cut -d' ' -f2)
     echo "$RECOVERED_ROOT_HEAD" > "$ROOT_HEAD_FILE"
     say "Recovered $ROOT HEAD, set to $RECOVERED_ROOT_HEAD"
     CORRUPT_ROOT_HEAD=false
@@ -385,7 +386,7 @@ fi
 if ! git gc --auto --force; then
   ERR="git prune failed"
   git prune
-  rm -rf "$TOP_LEVEL_DIRECTORY/.git/gc.log"
+  rm -rf "${GIT_DIR}/gc.log"
 fi
 
 if [[ -d "$LAST_WORKING_DIRECTORY" ]]; then


### PR DESCRIPTION
Allow supporting GIT_ROOT when defined where the GIT_ROOT location is different than the toplevel.

I am using this with [yadm](https://github.com/TheLocehiliosan/yadm) i.e: 

```
yadm enter git-fresh
```

since the way works yadm is to redefine GIT_ROOT (and WORKTREE)  let git-fresh handles that.